### PR TITLE
use symfony/routing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.6.0",
         "contao/core-bundle": ">=4.4.0,<5.0",
-        "sensio/framework-extra-bundle": "^5.0"
+        "symfony/routing": "^3.0 || ^4.0"
     },
     "autoload": {
         "classmap": [

--- a/src/Controller/BackupDbController.php
+++ b/src/Controller/BackupDbController.php
@@ -12,8 +12,8 @@ namespace Softleister\BackupDbBundle\Controller;
 
 use Softleister\BackupDB\AutoBackupDB;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Handles the AutoBackup frontend routes.


### PR DESCRIPTION
`"sensio/framework-extra-bundle": "^5.0"` is a pretty high requirement which makes this extension incompatible with other extensions that still might only require `"sensio/framework-extra-bundle": "^3.0"` for example.

Since you only need the `@Route` annotation anyway, it's better to use Symfony's own `symfony/routing` package, which includes a `@Route` annotation. This package is also used by Contao 4.4 and later.