### PR TITLE
Fix root open_basedir error

### DIFF
--- a/src/Resources/contao/classes/BackupDbCommon.php
+++ b/src/Resources/contao/classes/BackupDbCommon.php
@@ -405,20 +405,21 @@ class BackupDbCommon extends \Backend
     //------------------------------------------------
     //  iterateDir: rekusives Suchen nach Symlinks
     //------------------------------------------------
-    public static function iterateDir( $startPath )
+    public static function iterateDir($startPath)
     {
-        foreach( new \DirectoryIterator( $startPath ) as $objItem ) {
-            if( $objItem->isLink( ) ) {
-                Self::$arrSymlinks[] = $objItem->getPath( ) . '/' . $objItem->getFilename( );
+        foreach(new \DirectoryIterator($startPath) as $objItem) {
+            if($objItem->isDot()) {
                 continue;
             }
-            if($objItem->isDir( ) ) {
-                if( !$objItem->isDot( ) ) Self::iterateDir( $objItem->getPathname(), $arrResult );
+            if($objItem->isLink()) {
+                self::$arrSymlinks[] = $objItem->getPath() . '/' . $objItem->getFilename();
                 continue;
             }
-            if( $objItem->isLink() ) Self::$arrSymlinks[] = $objItem->getPath( ) . '/' . $objItem->getFilename( );
+            if($objItem->isDir()) {
+                self::iterateDir($objItem->getPathname());
+                continue;
+            }
         }
-        return;
     }
 
     //------------------------------------------------


### PR DESCRIPTION
Moin,

Wenn Contao im Root Verzeichnis des open_basedir liegt, kommt folgender Fehler:

`[2021-03-13 02:01:37] request.CRITICAL: Uncaught PHP Exception RuntimeException: "SplFileInfo::isLink(): open_basedir restriction in effect. File(/var/www/zf1006/htdocs/..) is not within the allowed path(s): (/var/www/zf1006/htdocs/:/var/www/zf1006/apps/:/var/www/zf1006/priv/:/var/www/zf1006/tmp/:/usr/share/pear/:/usr/share/php/)" at /var/www/zf1006/htdocs/vendor/do-while/contao-backupdb-bundle/src/Resources/contao/classes/BackupDbCommon.php line 411 {"exception":"[object] (RuntimeException(code: 0): SplFileInfo::isLink(): open_basedir restriction in effect. File(/var/www/zf1006/htdocs/..) is not within the allowed path(s): (/var/www/zf1006/htdocs/:/var/www/zf1006/apps/:/var/www/zf1006/priv/:/var/www/zf1006/tmp/:/usr/share/pear/:/usr/share/php/) at /var/www/zf1006/htdocs/vendor/do-while/contao-backupdb-bundle/src/Resources/contao/classes/BackupDbCommon.php:411)"} []`

Dieser Fix prüft als erstes nach einem Dot Verzeichnis und überspringt diese einfach, so das der Fehler nichtmehr auftreten kann.